### PR TITLE
feat: scaffold jobkit engine and worker

### DIFF
--- a/jobkit/__init__.py
+++ b/jobkit/__init__.py
@@ -1,0 +1,7 @@
+"""Jobkit: backend-agnostic job processing toolkit."""
+
+from .engine import Engine
+from .worker import Worker
+from .contracts import Executor, QueueBackend, ExecContext
+
+__all__ = ["Engine", "Worker", "Executor", "QueueBackend", "ExecContext"]

--- a/jobkit/backends/__init__.py
+++ b/jobkit/backends/__init__.py
@@ -1,0 +1,6 @@
+"""Backend implementations."""
+
+from .memory import MemoryBackend
+from .sql.backend import SQLBackend
+
+__all__ = ["MemoryBackend", "SQLBackend"]

--- a/jobkit/backends/sql/__init__.py
+++ b/jobkit/backends/sql/__init__.py
@@ -1,0 +1,6 @@
+"""SQL backend helpers."""
+
+from .backend import SQLBackend
+from .schema import JobTasks, metadata
+
+__all__ = ["SQLBackend", "JobTasks", "metadata"]

--- a/jobkit/backends/sql/backend.py
+++ b/jobkit/backends/sql/backend.py
@@ -1,0 +1,191 @@
+"""SQL backend implemented with SQLAlchemy async sessions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, List
+from uuid import UUID, uuid4
+
+from sqlalchemy import func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from .schema import JobTasks
+
+UTC = timezone.utc
+
+
+class SQLBackend:
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        *,
+        prefer_pg_skip_locked: bool = True,
+        lease_ttl_s: int = 30,
+    ) -> None:
+        self.engine = engine
+        self.prefer_pg_skip_locked = prefer_pg_skip_locked
+        self.lease_ttl_s = lease_ttl_s
+        self.sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def enqueue(self, **kwargs):  # type: ignore[override]
+        job_id = uuid4()
+        now = datetime.now(UTC)
+        values = dict(
+            id=str(job_id),
+            status="queued",
+            created_at=now,
+            scheduled_for=kwargs.get("scheduled_for") or now,
+            max_attempts=kwargs.get("max_attempts", 3),
+            priority=kwargs.get("priority", 100),
+            kind=kwargs["kind"],
+            payload=kwargs.get("payload", {}),
+            idempotency_key=kwargs.get("idempotency_key"),
+            timeout_s=kwargs.get("timeout_s"),
+        )
+        async with self.sessionmaker() as session:
+            await session.execute(JobTasks.insert().values(**values))
+            await session.commit()
+        return job_id
+
+    async def get(self, job_id: UUID) -> dict:  # type: ignore[override]
+        async with self.sessionmaker() as session:
+            row = (
+                await session.execute(select(JobTasks).where(JobTasks.c.id == str(job_id)))
+            ).mappings().first()
+            if not row:
+                raise KeyError(job_id)
+            return self._row_to_dict(row)
+
+    async def cancel(self, job_id: UUID) -> None:  # type: ignore[override]
+        async with self.sessionmaker() as session:
+            await session.execute(
+                update(JobTasks).where(JobTasks.c.id == str(job_id)).values(cancel_requested=True)
+            )
+            await session.commit()
+
+    async def claim_batch(self, worker_id: UUID, *, limit: int = 1) -> List[dict]:  # type: ignore[override]
+        if self.engine.dialect.name == "postgresql" and self.prefer_pg_skip_locked:
+            rows = await self._claim_pg(worker_id, limit)
+        else:
+            rows = await self._claim_generic(worker_id, limit)
+        return [self._row_to_dict(row) for row in rows]
+
+    async def _claim_pg(self, worker_id: UUID, limit: int) -> Iterable[dict]:
+        sql = text(
+            """
+            WITH picked AS (
+                SELECT id FROM job_tasks
+                WHERE status='queued' AND scheduled_for <= NOW()
+                ORDER BY priority ASC, created_at ASC
+                LIMIT :limit
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE job_tasks jt
+               SET leased_by=:worker,
+                   lease_until=NOW() + (:ttl * interval '1 second'),
+                   version=jt.version+1
+             FROM picked
+            WHERE jt.id = picked.id
+            RETURNING jt.*;
+            """
+        )
+        async with self.sessionmaker() as session:
+            rows = (
+                await session.execute(
+                    sql,
+                    {"worker": str(worker_id), "ttl": self.lease_ttl_s, "limit": limit},
+                )
+            ).mappings().all()
+            await session.commit()
+            return rows
+
+    async def _claim_generic(self, worker_id: UUID, limit: int) -> Iterable[dict]:
+        picked: list[dict] = []
+        async with self.sessionmaker() as session:
+            for _ in range(limit):
+                query = (
+                    select(JobTasks)
+                    .where(JobTasks.c.status == "queued")
+                    .where(JobTasks.c.scheduled_for <= func.now())
+                    .where(
+                        (JobTasks.c.lease_until.is_(None))
+                        | (JobTasks.c.lease_until <= func.now())
+                    )
+                    .order_by(JobTasks.c.priority.asc(), JobTasks.c.created_at.asc())
+                    .limit(1)
+                )
+                row = (await session.execute(query)).mappings().first()
+                if not row:
+                    break
+                job_id = row["id"]
+                lease_until = datetime.now(UTC) + timedelta(seconds=self.lease_ttl_s)
+                stmt = (
+                    update(JobTasks)
+                    .where(JobTasks.c.id == job_id)
+                    .where(JobTasks.c.version == row["version"])
+                    .values(
+                        leased_by=str(worker_id),
+                        lease_until=lease_until,
+                        version=JobTasks.c.version + 1,
+                    )
+                )
+                res = await session.execute(stmt)
+                if res.rowcount:
+                    await session.commit()
+                    picked.append(row)
+                else:
+                    await session.rollback()
+            return picked
+
+    async def mark_running(self, job_id: UUID, worker_id: UUID) -> None:  # type: ignore[override]
+        async with self.sessionmaker() as session:
+            await session.execute(
+                update(JobTasks)
+                .where(JobTasks.c.id == str(job_id))
+                .values(
+                    status="running",
+                    started_at=datetime.now(UTC),
+                    attempts=JobTasks.c.attempts + 1,
+                )
+            )
+            await session.commit()
+
+    async def extend_lease(self, job_id: UUID, worker_id: UUID, ttl_s: int) -> None:  # type: ignore[override]
+        async with self.sessionmaker() as session:
+            await session.execute(
+                update(JobTasks)
+                .where(JobTasks.c.id == str(job_id))
+                .where(JobTasks.c.leased_by == str(worker_id))
+                .values(lease_until=datetime.now(UTC) + timedelta(seconds=ttl_s))
+            )
+            await session.commit()
+
+    async def succeed(self, job_id: UUID, result: dict) -> None:  # type: ignore[override]
+        await self._finish(job_id, "success", result)
+
+    async def fail(self, job_id: UUID, reason: dict) -> None:  # type: ignore[override]
+        await self._finish(job_id, "failed", reason)
+
+    async def timeout(self, job_id: UUID) -> None:  # type: ignore[override]
+        await self._finish(job_id, "timeout", {"error": "timeout"})
+
+    async def _finish(self, job_id: UUID, status: str, result: dict) -> None:
+        async with self.sessionmaker() as session:
+            await session.execute(
+                update(JobTasks)
+                .where(JobTasks.c.id == str(job_id))
+                .values(
+                    status=status,
+                    finished_at=datetime.now(UTC),
+                    result=result,
+                    lease_until=None,
+                    leased_by=None,
+                )
+            )
+            await session.commit()
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict:
+        data = dict(row)
+        data["id"] = UUID(data["id"]) if isinstance(data["id"], str) else data["id"]
+        return data

--- a/jobkit/backends/sql/schema.py
+++ b/jobkit/backends/sql/schema.py
@@ -1,0 +1,62 @@
+"""SQLAlchemy Core schema for job tasks."""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.mysql import JSON as MYSQL_JSON
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.sqlite import JSON as SQLITE_JSON
+
+metadata = MetaData()
+
+JobTasks = Table(
+    "job_tasks",
+    metadata,
+    Column("id", String(36), primary_key=True),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.current_timestamp()),
+    Column("scheduled_for", DateTime(timezone=True), nullable=False, server_default=func.current_timestamp()),
+    Column("started_at", DateTime(timezone=True)),
+    Column("finished_at", DateTime(timezone=True)),
+    Column("status", Text, nullable=False, server_default="queued"),
+    Column("attempts", Integer, nullable=False, server_default="0"),
+    Column("max_attempts", Integer, nullable=False, server_default="3"),
+    Column("priority", Integer, nullable=False, server_default="100"),
+    Column("kind", Text, nullable=False),
+    Column(
+        "payload",
+        JSON().with_variant(JSONB, "postgresql")
+        .with_variant(MYSQL_JSON, "mysql")
+        .with_variant(SQLITE_JSON, "sqlite"),
+        nullable=False,
+    ),
+    Column(
+        "result",
+        JSON().with_variant(JSONB, "postgresql")
+        .with_variant(MYSQL_JSON, "mysql")
+        .with_variant(SQLITE_JSON, "sqlite"),
+    ),
+    Column("idempotency_key", Text, unique=True),
+    Column("cancel_requested", Boolean, nullable=False, server_default="0"),
+    Column("leased_by", String(36)),
+    Column("lease_until", DateTime(timezone=True)),
+    Column("version", Integer, nullable=False, server_default="0"),
+    Column("timeout_s", Integer),
+    CheckConstraint(
+        "status IN ('queued','running','success','failed','cancelled','timeout')",
+        name="job_status_chk",
+    ),
+)
+
+__all__ = ["JobTasks", "metadata"]

--- a/jobkit/cli.py
+++ b/jobkit/cli.py
@@ -1,0 +1,54 @@
+"""Entry-point for the ``jobkit-worker`` console script."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from .backends.sql import SQLBackend
+from .engine import Engine
+from .executors import HttpExecutor, SubprocessExecutor
+from .worker import Worker
+
+
+async def _run_worker(args: argparse.Namespace) -> None:
+    engine = create_async_engine(args.dsn)
+    backend = SQLBackend(
+        engine,
+        prefer_pg_skip_locked=not args.disable_skip_locked,
+        lease_ttl_s=args.lease_ttl,
+    )
+    eng = Engine(backend=backend, executors=[SubprocessExecutor(), HttpExecutor()])
+    worker = Worker(
+        eng,
+        max_concurrency=args.concurrency,
+        batch=args.batch,
+        poll_interval=args.poll_interval,
+        lease_ttl=args.lease_ttl,
+    )
+    await worker.run()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a Jobkit worker loop")
+    parser.add_argument("--dsn", required=True, help="SQLAlchemy async DSN")
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--lease-ttl", type=int, default=30)
+    parser.add_argument("--poll-interval", type=float, default=0.5)
+    parser.add_argument(
+        "--disable-skip-locked",
+        action="store_true",
+        help="Disable Postgres SKIP LOCKED optimization",
+    )
+    args = parser.parse_args()
+    try:
+        asyncio.run(_run_worker(args))
+    except KeyboardInterrupt:  # pragma: no cover - CLI convenience
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/jobkit/contracts.py
+++ b/jobkit/contracts.py
@@ -1,0 +1,73 @@
+"""Core contracts used by Jobkit components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Protocol
+from uuid import UUID
+
+
+class ExecContext(Protocol):
+    """Execution context passed to executors."""
+
+    async def log(self, message: str, /, *, stream: str = "stdout") -> None: ...
+
+    async def is_cancelled(self) -> bool: ...
+
+    async def set_progress(self, value: float, /, **meta: Any) -> None: ...
+
+
+class Executor(Protocol):
+    """Protocol for executor implementations."""
+
+    kind: str
+
+    async def run(self, *, job_id: UUID, payload: dict, ctx: ExecContext) -> dict: ...
+
+
+class QueueBackend(Protocol):
+    """Interface for queue backends."""
+
+    async def enqueue(
+        self,
+        *,
+        kind: str,
+        payload: dict,
+        priority: int = 100,
+        scheduled_for: datetime | None = None,
+        max_attempts: int = 3,
+        idempotency_key: str | None = None,
+        timeout_s: int | None = None,
+    ) -> UUID: ...
+
+    async def get(self, job_id: UUID) -> dict: ...
+
+    async def cancel(self, job_id: UUID) -> None: ...
+
+    async def claim_batch(self, worker_id: UUID, *, limit: int = 1) -> list[dict]: ...
+
+    async def mark_running(self, job_id: UUID, worker_id: UUID) -> None: ...
+
+    async def extend_lease(self, job_id: UUID, worker_id: UUID, ttl_s: int) -> None: ...
+
+    async def succeed(self, job_id: UUID, result: dict) -> None: ...
+
+    async def fail(self, job_id: UUID, reason: dict) -> None: ...
+
+    async def timeout(self, job_id: UUID) -> None: ...
+
+
+@dataclass(slots=True)
+class LogRecord:
+    job_id: UUID
+    stream: str
+    message: str
+
+
+class LogSink(Protocol):
+    async def write(self, record: LogRecord) -> None: ...
+
+
+class EventBus(Protocol):
+    async def publish(self, topic: str, payload: dict) -> None: ...

--- a/jobkit/engine.py
+++ b/jobkit/engine.py
@@ -1,0 +1,81 @@
+"""Engine facade exposed to library users."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable
+from uuid import UUID
+
+from .contracts import EventBus, ExecContext, Executor, LogRecord, LogSink, QueueBackend
+from .events.local import LocalEventBus
+from .logging.memory import MemoryLogSink
+
+
+@dataclass(slots=True)
+class _Ctx(ExecContext):  # type: ignore[misc]
+    job_id: UUID
+    log_sink: LogSink
+    event_bus: EventBus
+
+    async def log(self, message: str, /, *, stream: str = "stdout") -> None:  # type: ignore[override]
+        await self.log_sink.write(LogRecord(self.job_id, stream, message))
+
+    async def is_cancelled(self) -> bool:  # type: ignore[override]
+        return False  # TODO: expose cancellation from backend
+
+    async def set_progress(self, value: float, /, **meta):  # type: ignore[override]
+        await self.event_bus.publish(
+            f"job.{self.job_id}.progress",
+            {"value": value, **meta},
+        )
+
+
+class Engine:
+    """Front-end for enqueueing and introspecting jobs."""
+
+    def __init__(
+        self,
+        *,
+        backend: QueueBackend,
+        executors: Iterable[Executor],
+        log_sink: LogSink | None = None,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        self.backend = backend
+        self.executors = {e.kind: e for e in executors}
+        self.log_sink = log_sink or MemoryLogSink()
+        self.event_bus = event_bus or LocalEventBus()
+
+    async def enqueue(
+        self,
+        *,
+        kind: str,
+        payload: dict,
+        priority: int = 100,
+        scheduled_for: datetime | None = None,
+        max_attempts: int = 3,
+        idempotency_key: str | None = None,
+        timeout_s: int | None = None,
+    ) -> UUID:
+        return await self.backend.enqueue(
+            kind=kind,
+            payload=payload,
+            priority=priority,
+            scheduled_for=scheduled_for,
+            max_attempts=max_attempts,
+            idempotency_key=idempotency_key,
+            timeout_s=timeout_s,
+        )
+
+    async def get(self, job_id: UUID) -> dict:
+        return await self.backend.get(job_id)
+
+    async def cancel(self, job_id: UUID) -> None:
+        await self.backend.cancel(job_id)
+
+    def executor_for(self, kind: str) -> Executor | None:
+        return self.executors.get(kind)
+
+    def make_ctx(self, job_id: UUID) -> ExecContext:
+        return _Ctx(job_id, self.log_sink, self.event_bus)

--- a/jobkit/events/__init__.py
+++ b/jobkit/events/__init__.py
@@ -1,0 +1,5 @@
+"""Event bus helpers."""
+
+from .local import LocalEventBus
+
+__all__ = ["LocalEventBus"]

--- a/jobkit/events/local.py
+++ b/jobkit/events/local.py
@@ -1,0 +1,22 @@
+"""Minimal in-process event bus."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Awaitable, Callable, DefaultDict, List
+
+from ..contracts import EventBus
+
+
+class LocalEventBus(EventBus):
+    """Fire-and-forget bus storing subscribers in-memory."""
+
+    def __init__(self) -> None:
+        self._subs: DefaultDict[str, List[Callable[[dict], Awaitable[None]]]] = defaultdict(list)
+
+    def subscribe(self, topic: str, handler: Callable[[dict], Awaitable[None]]) -> None:
+        self._subs[topic].append(handler)
+
+    async def publish(self, topic: str, payload: dict) -> None:  # type: ignore[override]
+        await asyncio.gather(*(handler(payload) for handler in self._subs.get(topic, ())), return_exceptions=True)

--- a/jobkit/executors/__init__.py
+++ b/jobkit/executors/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in executor implementations."""
+
+from .subprocess import SubprocessExecutor
+from .http import HttpExecutor
+
+__all__ = ["SubprocessExecutor", "HttpExecutor"]

--- a/jobkit/executors/http.py
+++ b/jobkit/executors/http.py
@@ -1,0 +1,56 @@
+"""HTTP executor built on httpx.AsyncClient."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+
+from ..contracts import ExecContext
+
+
+class HttpExecutor:
+    kind = "http"
+
+    async def run(self, *, job_id, payload: dict, ctx: ExecContext) -> dict:  # type: ignore[override]
+        method = payload.get("method", "GET").upper()
+        url = payload["url"]
+        timeout = payload.get("timeout", 30)
+        retries = payload.get("retries", 0)
+        backoff = payload.get("backoff", 0.5)
+        data = payload.get("data")
+        json_payload = payload.get("json")
+        headers = payload.get("headers")
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            attempt = 0
+            while True:
+                try:
+                    started = time.perf_counter()
+                    resp = await client.request(
+                        method,
+                        url,
+                        data=data,
+                        json=json_payload,
+                        headers=headers,
+                    )
+                    duration = int((time.perf_counter() - started) * 1000)
+                    await ctx.log(f"{method} {url} -> {resp.status_code} in {duration}ms")
+                    body: object
+                    if "application/json" in resp.headers.get("content-type", ""):
+                        body = resp.json()
+                    else:
+                        body = resp.text
+                    return {
+                        "status": resp.status_code,
+                        "headers": dict(resp.headers),
+                        "body": body,
+                        "duration_ms": duration,
+                    }
+                except Exception as exc:
+                    if attempt >= retries:
+                        await ctx.log(f"http executor failed: {exc}", stream="stderr")
+                        raise
+                    await ctx.log(f"attempt {attempt+1} failed: {exc}", stream="stderr")
+                    await asyncio.sleep(backoff * (2**attempt))
+                    attempt += 1

--- a/jobkit/executors/subprocess.py
+++ b/jobkit/executors/subprocess.py
@@ -1,0 +1,54 @@
+"""Subprocess executor streaming stdout/stderr into the log sink."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from ..contracts import ExecContext
+
+
+class SubprocessExecutor:
+    kind = "subprocess"
+
+    async def run(self, *, job_id, payload: dict, ctx: ExecContext) -> dict:  # type: ignore[override]
+        cmd = payload["cmd"]
+        env = payload.get("env")
+        cwd = payload.get("cwd")
+        shell = isinstance(cmd, str)
+        start = time.perf_counter()
+        if shell:
+            proc = await asyncio.create_subprocess_shell(
+                cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+        else:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+
+        async def _pump(stream: asyncio.StreamReader | None, name: str) -> None:
+            if stream is None:
+                return
+            while True:
+                chunk = await stream.readline()
+                if not chunk:
+                    break
+                await ctx.log(chunk.decode(errors="ignore"), stream=name)
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(_pump(proc.stdout, "stdout"))
+            tg.create_task(_pump(proc.stderr, "stderr"))
+        rc = await proc.wait()
+        return {
+            "returncode": rc,
+            "duration_ms": int((time.perf_counter() - start) * 1000),
+        }

--- a/jobkit/logging/__init__.py
+++ b/jobkit/logging/__init__.py
@@ -1,0 +1,5 @@
+"""Logging helpers."""
+
+from .memory import MemoryLogSink
+
+__all__ = ["MemoryLogSink"]

--- a/jobkit/logging/memory.py
+++ b/jobkit/logging/memory.py
@@ -1,0 +1,30 @@
+"""In-process log sink useful for tests and demos."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict, deque
+from typing import Deque, Dict, List
+from uuid import UUID
+
+from ..contracts import LogRecord, LogSink
+
+
+class MemoryLogSink(LogSink):
+    """Simple log sink storing lines per job."""
+
+    def __init__(self, *, max_items: int = 1000) -> None:
+        self._max_items = max_items
+        self._logs: Dict[UUID, Deque[LogRecord]] = defaultdict(deque)
+        self._lock = asyncio.Lock()
+
+    async def write(self, record: LogRecord) -> None:  # type: ignore[override]
+        async with self._lock:
+            log = self._logs[record.job_id]
+            if len(log) >= self._max_items:
+                log.popleft()
+            log.append(record)
+
+    async def get(self, job_id: UUID) -> List[LogRecord]:
+        async with self._lock:
+            return list(self._logs.get(job_id, ()))

--- a/jobkit/worker.py
+++ b/jobkit/worker.py
@@ -1,0 +1,90 @@
+"""Async worker implementation built on asyncio.TaskGroup."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from contextlib import suppress
+from typing import Any
+from uuid import UUID, uuid4
+
+from .engine import Engine
+
+
+class Worker:
+    def __init__(
+        self,
+        engine: Engine,
+        *,
+        max_concurrency: int = 8,
+        batch: int = 1,
+        poll_interval: float = 0.5,
+        lease_ttl: int = 30,
+    ) -> None:
+        self.engine = engine
+        self.max_concurrency = max_concurrency
+        self.batch = batch
+        self.poll_interval = poll_interval
+        self.lease_ttl = lease_ttl
+        self.worker_id = uuid4()
+        self._stop = asyncio.Event()
+        self._sem = asyncio.Semaphore(max_concurrency)
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def run(self) -> None:
+        while not self._stop.is_set():
+            rows = await self.engine.backend.claim_batch(self.worker_id, limit=self.batch)
+            if not rows:
+                await asyncio.sleep(self._jitter(self.poll_interval))
+                continue
+
+            async with asyncio.TaskGroup() as tg:
+                for row in rows:
+                    await self._sem.acquire()
+                    tg.create_task(self._run_row(row))
+
+    async def _run_row(self, row: dict[str, Any]) -> None:
+        try:
+            await self._execute_row(row)
+        finally:
+            self._sem.release()
+
+    async def _execute_row(self, row: dict[str, Any]) -> None:
+        job_id = UUID(row["id"]) if not isinstance(row["id"], UUID) else row["id"]
+        executor = self.engine.executor_for(row["kind"])
+        if executor is None:
+            await self.engine.backend.fail(job_id, {"error": "unknown_kind", "kind": row["kind"]})
+            return
+        ctx = self.engine.make_ctx(job_id)
+        lease_task = asyncio.create_task(self._extend_loop(job_id))
+        try:
+            await self.engine.backend.mark_running(job_id, self.worker_id)
+            timeout = row.get("timeout_s") or 300
+            async with asyncio.timeout(timeout):
+                result = await executor.run(job_id=job_id, payload=row["payload"], ctx=ctx)
+            await self.engine.backend.succeed(job_id, result)
+        except asyncio.TimeoutError:
+            await self.engine.backend.timeout(job_id)
+        except asyncio.CancelledError:
+            await self.engine.backend.fail(job_id, {"error": "cancelled"})
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            await self.engine.backend.fail(job_id, {"error": repr(exc)})
+        finally:
+            lease_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await lease_task
+
+    async def _extend_loop(self, job_id: UUID) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self.lease_ttl * 0.5)
+                await self.engine.backend.extend_lease(job_id, self.worker_id, self.lease_ttl)
+        except asyncio.CancelledError:
+            return
+
+    @staticmethod
+    def _jitter(value: float) -> float:
+        return value * (0.8 + random.random() * 0.4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "jobkit"
+version = "0.1.0"
+description = "Backend-agnostic job processing toolkit"
+requires-python = ">=3.13"
+dependencies = [
+    "sqlalchemy[asyncio]>=2.0",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+pg = ["asyncpg"]
+mysql = ["aiomysql"]
+sqlite = ["aiosqlite"]
+
+[project.scripts]
+jobkit-worker = "jobkit.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add the initial jobkit package with contracts, engine, worker, executors, and supporting adapters
- provide memory and SQLAlchemy-based queue backends plus a CLI entry-point and project metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195578275083258573a4683dbd724c)