### PR TITLE
Limit CI workflow to pyjobkit repository

### DIFF
--- a/.github/workflows/pyjobkit_pipeline.yml
+++ b/.github/workflows/pyjobkit_pipeline.yml
@@ -1,0 +1,30 @@
+name: PyJobKit Pipeline
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    if: endsWith(github.repository, '/pyjobkit')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          allow-prereleases: true
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- rename the workflow to `pyjobkit_pipeline.yml` to clarify its purpose
- ensure the test job only runs when the repository name ends with `/pyjobkit`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195f7bac408325ac39e47f4e47efe2)