### PR TITLE
Add FastAPI taskboard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Use `--disable-skip-locked` when targeting databases that do not support the Pos
 - **Alternate backends** – Implement the `QueueBackend` protocol to target message brokers or proprietary queues while reusing the worker and executor layers.
 - **Logging & events** – Swap the memory log sink or event bus with your own implementations (e.g., stream to Loki or publish over Redis) by passing them to the `Engine` constructor.
 
+## Examples
+- [`examples/taskboard`](examples/taskboard) – A single-page FastAPI dashboard that enqueues demo jobs which sleep for a random duration using the in-memory backend. Includes a Dockerfile for quick demos.
+
 ## Requirements
 - Python 3.13+
 - An asyncio-compatible event loop (the worker uses `asyncio.TaskGroup`)

--- a/examples/taskboard/Dockerfile
+++ b/examples/taskboard/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir . fastapi uvicorn
+
+EXPOSE 8000
+
+CMD ["uvicorn", "examples.taskboard.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/examples/taskboard/README.md
+++ b/examples/taskboard/README.md
@@ -1,0 +1,35 @@
+# Taskboard demo
+
+This example spins up a FastAPI application plus an in-process Jobkit worker.  The
+single-page UI lets you enqueue demo jobs that simply sleep for a random
+interval and then complete.
+
+## Running locally
+
+1. Install Jobkit and the extra demo dependencies:
+
+   ```bash
+   pip install -e .
+   pip install fastapi uvicorn
+   ```
+
+2. Start the web server (it also runs the worker loop in the background):
+
+   ```bash
+   uvicorn examples.taskboard.app:app --reload
+   ```
+
+Visit <http://127.0.0.1:8000/> and click **Enqueue demo job** to populate the
+table.
+
+## Docker
+
+You can also run the demo in a container built from the repository root:
+
+```bash
+docker build -f examples/taskboard/Dockerfile -t jobkit-taskboard .
+docker run --rm -p 8000:8000 jobkit-taskboard
+```
+
+The container uses the in-memory backend, so job history is reset whenever the
+process restarts.

--- a/examples/taskboard/app.py
+++ b/examples/taskboard/app.py
@@ -1,0 +1,193 @@
+"""One-page demo dashboard for Jobkit using FastAPI and the memory backend."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from contextlib import suppress
+from datetime import datetime
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+from jobkit import Engine, Worker
+from jobkit.backends.memory import MemoryBackend
+from jobkit.contracts import ExecContext, Executor
+
+
+class InspectableMemoryBackend(MemoryBackend):
+    """Memory backend variant that exposes a helper to list jobs."""
+
+    async def list_jobs(self) -> list[dict[str, Any]]:
+        async with self._lock:  # type: ignore[attr-defined]
+            return [self._job_to_dict(job) for job in self._jobs.values()]  # type: ignore[attr-defined]
+
+
+class DemoSleepExecutor(Executor):
+    kind = "demo.sleep"
+
+    async def run(self, *, job_id, payload, ctx: ExecContext):  # type: ignore[override]
+        label = payload.get("label", str(job_id))
+        duration = float(payload.get("duration", random.uniform(1.0, 4.0)))
+        steps = 5
+        for step in range(steps):
+            await ctx.log(f"{label}: working chunk {step + 1}/{steps}")
+            await ctx.set_progress((step + 1) / steps)
+            await asyncio.sleep(duration / steps)
+        message = f"{label} finished in {duration:.2f}s"
+        return {"message": message, "duration": duration}
+
+
+backend = InspectableMemoryBackend()
+engine = Engine(backend=backend, executors=[DemoSleepExecutor()])
+worker = Worker(engine, max_concurrency=4, batch=4)
+app = FastAPI(title="Jobkit taskboard demo")
+
+
+@app.on_event("startup")
+async def start_worker() -> None:
+    app.state.worker_task = asyncio.create_task(worker.run())
+
+
+@app.on_event("shutdown")
+async def stop_worker() -> None:
+    worker.request_stop()
+    task: asyncio.Task[None] | None = getattr(app.state, "worker_task", None)
+    if task:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> str:
+    return PAGE_HTML
+
+
+@app.post("/api/jobs")
+async def enqueue_job() -> dict[str, Any]:
+    duration = round(random.uniform(1.0, 5.0), 2)
+    label = f"Demo #{random.randint(1000, 9999)}"
+    payload = {"duration": duration, "label": label}
+    job_id = await engine.enqueue(kind=DemoSleepExecutor.kind, payload=payload)
+    return {"id": str(job_id), "label": label, "duration": duration}
+
+
+@app.get("/api/jobs")
+async def list_jobs() -> list[dict[str, Any]]:
+    jobs = await backend.list_jobs()
+    jobs.sort(key=lambda job: job["created_at"])
+    return [_serialize_job(job) for job in jobs]
+
+
+def _serialize_job(job: dict[str, Any]) -> dict[str, Any]:
+    payload = job.get("payload", {})
+    result = job.get("result")
+    if isinstance(result, dict):
+        result_payload = result
+    else:
+        result_payload = result
+
+    return {
+        "id": str(job["id"]),
+        "label": payload.get("label", str(job["id"])),
+        "duration": payload.get("duration"),
+        "status": job.get("status"),
+        "attempts": job.get("attempts"),
+        "result": result_payload,
+        "created_at": _iso(job.get("created_at")),
+        "started_at": _iso(job.get("started_at")),
+        "finished_at": _iso(job.get("finished_at")),
+    }
+
+
+def _iso(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return None
+
+
+PAGE_HTML = """
+<!doctype html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\">
+    <title>Jobkit demo dashboard</title>
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; padding: 2rem; background: #f9fafb; }
+      h1 { margin-top: 0; }
+      button { background: #2563eb; color: white; border: none; padding: 0.75rem 1.5rem; border-radius: 0.5rem; font-size: 1rem; cursor: pointer; }
+      button:hover { background: #1d4ed8; }
+      table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; }
+      th, td { padding: 0.75rem; text-align: left; border-bottom: 1px solid #e5e7eb; }
+      th { background: #e0e7ff; }
+      tr:nth-child(even) { background: #f8fafc; }
+      .status { text-transform: capitalize; font-weight: 600; }
+      .status.queued { color: #92400e; }
+      .status.running { color: #1d4ed8; }
+      .status.success { color: #15803d; }
+      .status.failed { color: #b91c1c; }
+      .status.timeout { color: #b91c1c; }
+      .muted { color: #6b7280; font-size: 0.9rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Jobkit demo dashboard</h1>
+    <p>Press the button to enqueue demo jobs that sleep for a random duration.</p>
+    <button id=\"enqueue\">Enqueue demo job</button>
+    <table>
+      <thead>
+        <tr>
+          <th>Label</th>
+          <th>Status</th>
+          <th>Duration (s)</th>
+          <th>Result</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody id=\"jobs-body\">
+        <tr><td colspan=\"5\" class=\"muted\">No jobs yet</td></tr>
+      </tbody>
+    </table>
+    <script>
+      const body = document.getElementById('jobs-body');
+      const button = document.getElementById('enqueue');
+
+      async function refresh() {
+        const resp = await fetch('/api/jobs');
+        const jobs = await resp.json();
+        if (jobs.length === 0) {
+          body.innerHTML = '<tr><td colspan="5" class="muted">No jobs yet</td></tr>';
+          return;
+        }
+        body.innerHTML = jobs.map(job => {
+          const result = job.result ? JSON.stringify(job.result) : '';
+          return `<tr>
+            <td>${job.label}</td>
+            <td class="status ${job.status}">${job.status}</td>
+            <td>${job.duration ?? ''}</td>
+            <td><code>${result}</code></td>
+            <td>${job.created_at?.replace('T', ' ') ?? ''}</td>
+          </tr>`;
+        }).join('');
+      }
+
+      async function enqueue() {
+        button.disabled = true;
+        try {
+          await fetch('/api/jobs', { method: 'POST' });
+          await refresh();
+        } finally {
+          button.disabled = false;
+        }
+      }
+
+      button.addEventListener('click', enqueue);
+      refresh();
+      setInterval(refresh, 2000);
+    </script>
+  </body>
+</html>
+"""


### PR DESCRIPTION
## Summary
- add a FastAPI powered taskboard example that uses the in-memory backend, runs demo sleep jobs, and exposes a tiny dashboard
- include Docker packaging plus documentation so the example can be run locally or via containers
- reference the new example from the main README for discoverability

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jobkit'; package is not installed into the interpreter running pytest)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196925161883259d468ea7077a0795)