### PR TITLE
Add docker compose setup for taskboard demo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  taskboard:
+    container_name: jobkit-taskboard
+    build:
+      context: .
+      dockerfile: examples/taskboard/Dockerfile
+    ports:
+      - "8000:8000"
+    restart: unless-stopped

--- a/examples/taskboard/README.md
+++ b/examples/taskboard/README.md
@@ -31,5 +31,13 @@ docker build -f examples/taskboard/Dockerfile -t jobkit-taskboard .
 docker run --rm -p 8000:8000 jobkit-taskboard
 ```
 
-The container uses the in-memory backend, so job history is reset whenever the
-process restarts.
+If you're orchestrating containers with Docker Compose (or a tool like
+Portainer), the repository root ships with a `docker-compose.yml` that exposes
+the same FastAPI server as a `taskboard` service:
+
+```bash
+docker compose up --build taskboard
+```
+
+The container uses the in-memory backend in either case, so job history is
+reset whenever the process restarts.


### PR DESCRIPTION
## Summary
- add a root-level docker compose file that builds the taskboard example image and exposes port 8000 for easy deployment from Portainer or similar tools
- document the new `docker compose` workflow in the taskboard example README so users can pick between `docker run` and compose

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691980997fac8325a9c315e6bbeb26a5)