### PR TITLE
Add dockerignore to shrink taskboard build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Ignore Git metadata and CI configs
+.git
+.github
+
+# Python build and cache artifacts
+__pycache__
+*.py[cod]
+*.so
+*.egg-info
+.eggs
+dist
+build
+pip-wheel-metadata
+
+# Virtual environments
+.venv
+venv
+env
+
+# Local tooling/config noise
+*.log
+.idea
+.vscode
+.DS_Store
+
+# Test suites and coverage caches aren't needed in the container
+.coverage
+htmlcov
+.pytest_cache
+tests/
+
+# Keep the taskboard demo sources available but drop its own caches
+examples/taskboard/__pycache__


### PR DESCRIPTION
## Summary
- add a .dockerignore so Compose builds of the taskboard demo do not ship unnecessary files
- keep only the sources needed for packaging while excluding git metadata, tests, and caches to shrink the context

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jobkit' during test collection)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919843f2e688325b88a1d87d826ee9a)