### PR TITLE
Improve worker shutdown and CLI configurability

### DIFF
--- a/pyjobkit/__init__.py
+++ b/pyjobkit/__init__.py
@@ -2,6 +2,15 @@
 
 from .engine import Engine
 from .worker import Worker
-from .contracts import Executor, QueueBackend, ExecContext
+from .contracts import ExecContext, Executor, QueueBackend
 
-__all__ = ["Engine", "Worker", "Executor", "QueueBackend", "ExecContext"]
+__version__ = "0.1.0"
+
+__all__ = [
+    "Engine",
+    "Worker",
+    "Executor",
+    "QueueBackend",
+    "ExecContext",
+    "__version__",
+]

--- a/pyjobkit/engine.py
+++ b/pyjobkit/engine.py
@@ -11,6 +11,8 @@ from .contracts import EventBus, ExecContext, Executor, LogRecord, LogSink, Queu
 from .events.local import LocalEventBus
 from .logging.memory import MemoryLogSink
 
+PROGRESS_TOPIC_TEMPLATE = "job.{job_id}.progress"
+
 
 @dataclass(slots=True)
 class _Ctx(ExecContext):  # type: ignore[misc]
@@ -26,7 +28,7 @@ class _Ctx(ExecContext):  # type: ignore[misc]
 
     async def set_progress(self, value: float, /, **meta):  # type: ignore[override]
         await self.event_bus.publish(
-            f"job.{self.job_id}.progress",
+            PROGRESS_TOPIC_TEMPLATE.format(job_id=self.job_id),
             {"value": value, **meta},
         )
 


### PR DESCRIPTION
## Summary
- add explicit package version export and document backend claim payloads
- improve worker shutdown signaling and lease task cancellation behavior
- allow configurable executors via CLI and configure default logging

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aa3ecff0c8325b9fbc5a752373d4e)