### PR TITLE
Add worker health checks and safety fixes

### DIFF
--- a/examples/taskboard/app.py
+++ b/examples/taskboard/app.py
@@ -65,6 +65,11 @@ async def index() -> str:
     return PAGE_HTML
 
 
+@app.get("/health")
+async def health() -> dict[str, Any]:
+    return await worker.check_health()
+
+
 @app.post("/api/jobs")
 async def enqueue_job() -> dict[str, Any]:
     duration = round(random.uniform(1.0, 5.0), 2)

--- a/pyjobkit/backends/memory.py
+++ b/pyjobkit/backends/memory.py
@@ -172,6 +172,13 @@ class MemoryBackend(QueueBackend):
                 job.version += 1
             return len(expired)
 
+    async def queue_depth(self) -> int:  # type: ignore[override]
+        async with self._lock:
+            return sum(1 for job in self._jobs.values() if job.status == "queued")
+
+    async def check_connection(self) -> None:  # type: ignore[override]
+        return None
+
     async def _finish(
         self, job_id: UUID, status: str, result: dict, *, expected_version: int | None
     ) -> None:

--- a/pyjobkit/cli.py
+++ b/pyjobkit/cli.py
@@ -28,6 +28,9 @@ async def _run_worker(args: argparse.Namespace) -> None:
         module_name, _, attr = dotted_path.rpartition(":")
         if not module_name:
             raise ValueError("Executor path must be in 'module:attr' format")
+        allowed_modules = {"myapp.executors", "pyjobkit.executors"}
+        if not any(module_name.startswith(m) for m in allowed_modules):
+            raise ValueError(f"Module {module_name} not in allowlist")
         module = importlib.import_module(module_name)
         executors.append(getattr(module, attr)())
     eng = Engine(backend=backend, executors=executors)

--- a/pyjobkit/contracts.py
+++ b/pyjobkit/contracts.py
@@ -85,6 +85,10 @@ class QueueBackend(Protocol):
 
     async def reap_expired(self) -> int: ...
 
+    async def queue_depth(self) -> int: ...
+
+    async def check_connection(self) -> None: ...
+
 
 @dataclass(slots=True)
 class LogRecord:


### PR DESCRIPTION
## Summary
- add queue depth metrics and connection checks with worker health endpoint support
- harden MemoryLogSink for sync access and gate CLI executor imports with an allowlist
- track active jobs without private semaphore internals and expose health route in the example app

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab18cc1b88325a19a934e62cfef35)