### PR TITLE
Improve enqueue validation and clarify test context

### DIFF
--- a/pyjobkit/engine.py
+++ b/pyjobkit/engine.py
@@ -15,6 +15,7 @@ from .events.local import LocalEventBus
 from .logging.memory import MemoryLogSink
 
 PROGRESS_TOPIC_TEMPLATE = "job.{job_id}.progress"
+KIND_PATTERN = re.compile(r"[A-Za-z0-9_.-]+")
 logger = logging.getLogger(__name__)
 
 
@@ -87,7 +88,13 @@ class Engine:
         idempotency_key: str | None = None,
         timeout_s: int | None = None,
     ) -> UUID:
-        if not re.fullmatch(r"[A-Za-z0-9_.-]+", kind):
+        """Enqueue a job for processing and return its identifier.
+
+        The method's primary effect is placing the job into the backend queue; the
+        returned UUID allows callers to track execution progress later.
+        """
+
+        if not KIND_PATTERN.fullmatch(kind):
             raise ValueError("kind must contain only alphanumerics, dash, underscore, or dot")
         logger.info(
             "enqueue requested: kind=%s priority=%s scheduled_for=%s timeout_s=%s idempotency_key=%s",

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -13,7 +13,9 @@ from pyjobkit.executors.http import HttpExecutor
 from pyjobkit.executors.subprocess import SubprocessExecutor
 
 
-class _Ctx:
+class TestContext:
+    __test__ = False
+
     def __init__(self) -> None:
         self.logs: list[tuple[str, str]] = []
 
@@ -62,7 +64,7 @@ def test_http_executor_success(monkeypatch) -> None:
     async def _run() -> None:
         resp = _Response(200, {"content-type": "application/json"}, "{}", {"ok": True})
         _patch_http_client(monkeypatch, [resp])
-        ctx = _Ctx()
+        ctx = TestContext()
         executor = HttpExecutor()
         result = await executor.run(job_id=uuid4(), payload={"url": "https://example"}, ctx=ctx)
         assert result["status"] == 200
@@ -82,7 +84,7 @@ def test_http_executor_retries_and_fails(monkeypatch) -> None:
             calls.append(duration)
 
         monkeypatch.setattr("pyjobkit.executors.http.asyncio.sleep", fake_sleep)
-        ctx = _Ctx()
+        ctx = TestContext()
         executor = HttpExecutor()
         result = await executor.run(
             job_id=uuid4(),
@@ -102,7 +104,7 @@ def test_http_executor_retries_and_fails(monkeypatch) -> None:
 
 def test_subprocess_executor_exec_and_shell() -> None:
     async def _run() -> None:
-        ctx = _Ctx()
+        ctx = TestContext()
         executor = SubprocessExecutor()
         result = await executor.run(
             job_id=uuid4(),
@@ -112,7 +114,7 @@ def test_subprocess_executor_exec_and_shell() -> None:
         assert result["returncode"] == 0
         assert any(stream == "stderr" for stream, _ in ctx.logs)
 
-        ctx_shell = _Ctx()
+        ctx_shell = TestContext()
         result_shell = await executor.run(
             job_id=uuid4(),
             payload={"cmd": "python3 -c \"print('shell')\""},


### PR DESCRIPTION
## Summary
- precompile the job kind validation pattern and document the enqueue side effect/return value
- rename the test execution context helper for clarity and suppress pytest collection warnings

## Testing
- python -m pytest tests/test_executors.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bda40470c8325bd53cc4a9fc0477e)