### PR TITLE
Log backend reap failures

### DIFF
--- a/pyjobkit/worker.py
+++ b/pyjobkit/worker.py
@@ -152,8 +152,14 @@ class Worker:
                     await asyncio.wait_for(self._stop.wait(), timeout=self.lease_ttl)
                     return
                 except asyncio.TimeoutError:
-                    with suppress(Exception):
+                    try:
                         await self.engine.reap_expired()
+                    except Exception as exc:
+                        logger.warning(
+                            "reap_expired failed, continuing to retry: %s",
+                            exc,
+                            exc_info=True,
+                        )
         except asyncio.CancelledError:
             return
 


### PR DESCRIPTION
## Summary
- log backend reap_expired exceptions instead of silently suppressing them

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be6ff8de88325ad81a792429985d2)