### PR TITLE
Handle cancelled jobs without stopping worker

### DIFF
--- a/pyjobkit/worker.py
+++ b/pyjobkit/worker.py
@@ -120,7 +120,7 @@ class Worker:
             await self.engine.timeout(job_id, expected_version=expected_version)
         except asyncio.CancelledError:
             await self.engine.fail(job_id, {"error": "cancelled"}, expected_version=expected_version)
-            raise
+            return
         except Exception as exc:  # pragma: no cover - defensive
             attempts = (row.get("attempts") or 0) + 1
             if attempts >= row.get("max_attempts", 3):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -207,8 +207,7 @@ def test_worker_execute_cancelled_error() -> None:
 
         executor = _Executor(kind="boom", behavior=cancelled)
         worker = Worker(_Engine(backend, [executor]))
-        with pytest.raises(asyncio.CancelledError):
-            await worker._execute_row({"id": uuid4(), "kind": "boom", "payload": {}})
+        await worker._execute_row({"id": uuid4(), "kind": "boom", "payload": {}})
         assert backend.failed[0][1] == {"error": "cancelled"}
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- prevent cancelled job execution from propagating cancellation that stops the worker
- update the cancellation test to reflect graceful handling

## Testing
- pytest tests/test_worker.py::test_worker_execute_cancelled_error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be84062c48325bcab4bf4617789dd)