### PR TITLE
Kill subprocesses on cancellation or timeout

### DIFF
--- a/pyjobkit/executors/subprocess.py
+++ b/pyjobkit/executors/subprocess.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import suppress
 from typing import Any
 
 from ..contracts import ExecContext
@@ -18,37 +19,51 @@ class SubprocessExecutor:
         cwd = payload.get("cwd")
         shell = isinstance(cmd, str)
         start = time.perf_counter()
-        if shell:
-            proc = await asyncio.create_subprocess_shell(
-                cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-            )
-        else:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-            )
+        proc: asyncio.subprocess.Process | None = None
+        try:
+            if shell:
+                proc = await asyncio.create_subprocess_shell(
+                    cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=cwd,
+                    env=env,
+                )
+            else:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=cwd,
+                    env=env,
+                )
 
-        async def _pump(stream: asyncio.StreamReader | None, name: str) -> None:
-            if stream is None:
-                return
-            while True:
-                chunk = await stream.readline()
-                if not chunk:
-                    break
-                await ctx.log(chunk.decode(errors="ignore"), stream=name)
+            async def _pump(stream: asyncio.StreamReader | None, name: str) -> None:
+                if stream is None:
+                    return
+                while True:
+                    chunk = await stream.readline()
+                    if not chunk:
+                        break
+                    await ctx.log(chunk.decode(errors="ignore"), stream=name)
 
-        async with asyncio.TaskGroup() as tg:
-            tg.create_task(_pump(proc.stdout, "stdout"))
-            tg.create_task(_pump(proc.stderr, "stderr"))
-        rc = await proc.wait()
-        return {
-            "returncode": rc,
-            "duration_ms": int((time.perf_counter() - start) * 1000),
-        }
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(_pump(proc.stdout, "stdout"))
+                tg.create_task(_pump(proc.stderr, "stderr"))
+            rc = await proc.wait()
+            return {
+                "returncode": rc,
+                "duration_ms": int((time.perf_counter() - start) * 1000),
+            }
+        except asyncio.CancelledError:
+            if proc and proc.returncode is None:
+                proc.kill()
+                with suppress(asyncio.CancelledError):
+                    await proc.wait()
+            raise
+        except Exception:
+            if proc and proc.returncode is None:
+                proc.kill()
+                with suppress(asyncio.CancelledError):
+                    await proc.wait()
+            raise


### PR DESCRIPTION
## Summary
- ensure SubprocessExecutor terminates child processes when tasks are cancelled or fail
- add regression tests confirming subprocesses are killed on cancellation and worker timeouts

## Testing
- pytest tests/test_executors.py::test_subprocess_executor_exec_and_shell tests/test_executors.py::test_subprocess_executor_cancels_process tests/test_worker.py::test_worker_kills_subprocess_on_timeout -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf11c1d908325a55da9125798141a)