### PR TITLE
Convert contracts to ABCs and align implementations

### DIFF
--- a/examples/taskboard/app.py
+++ b/examples/taskboard/app.py
@@ -14,6 +14,7 @@ from fastapi.responses import HTMLResponse
 from pyjobkit import Engine, Worker
 from pyjobkit.backends.memory import MemoryBackend
 from pyjobkit.contracts import ExecContext, Executor
+from uuid import UUID
 
 
 class InspectableMemoryBackend(MemoryBackend):
@@ -27,7 +28,7 @@ class InspectableMemoryBackend(MemoryBackend):
 class DemoSleepExecutor(Executor):
     kind = "demo.sleep"
 
-    async def run(self, *, job_id, payload, ctx: ExecContext):  # type: ignore[override]
+    async def run(self, *, job_id: UUID, payload: dict, ctx: ExecContext) -> dict:
         label = payload.get("label", str(job_id))
         duration = float(payload.get("duration", random.uniform(1.0, 4.0)))
         steps = 5

--- a/pyjobkit/events/local.py
+++ b/pyjobkit/events/local.py
@@ -19,7 +19,7 @@ class LocalEventBus(EventBus):
     def subscribe(self, topic: str, handler: Callable[[dict], Awaitable[None]]) -> None:
         self._subs[topic].append(handler)
 
-    async def publish(self, topic: str, payload: dict) -> None:  # type: ignore[override]
+    async def publish(self, topic: str, payload: dict) -> None:
         results = await asyncio.gather(
             *(handler(payload) for handler in self._subs.get(topic, ())),
             return_exceptions=True,

--- a/pyjobkit/executors/http.py
+++ b/pyjobkit/executors/http.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import time
+from uuid import UUID
 
 import httpx
 
-from ..contracts import ExecContext
+from ..contracts import ExecContext, Executor
 
 
-class HttpExecutor:
+class HttpExecutor(Executor):
     kind = "http"
 
-    async def run(self, *, job_id, payload: dict, ctx: ExecContext) -> dict:  # type: ignore[override]
+    async def run(self, *, job_id: UUID, payload: dict, ctx: ExecContext) -> dict:
         method = payload.get("method", "GET").upper()
         url = payload["url"]
         timeout = payload.get("timeout", 30)

--- a/pyjobkit/executors/subprocess.py
+++ b/pyjobkit/executors/subprocess.py
@@ -6,14 +6,15 @@ import asyncio
 import time
 from contextlib import suppress
 from typing import Any
+from uuid import UUID
 
-from ..contracts import ExecContext
+from ..contracts import ExecContext, Executor
 
 
-class SubprocessExecutor:
+class SubprocessExecutor(Executor):
     kind = "subprocess"
 
-    async def run(self, *, job_id, payload: dict, ctx: ExecContext) -> dict:  # type: ignore[override]
+    async def run(self, *, job_id: UUID, payload: dict, ctx: ExecContext) -> dict:
         cmd = payload["cmd"]
         env = payload.get("env")
         cwd = payload.get("cwd")

--- a/pyjobkit/logging/memory.py
+++ b/pyjobkit/logging/memory.py
@@ -20,7 +20,7 @@ class MemoryLogSink(LogSink):
         self._lock = asyncio.Lock()
         self._thread_lock = threading.Lock()
 
-    async def write(self, record: LogRecord) -> None:  # type: ignore[override]
+    async def write(self, record: LogRecord) -> None:
         async with self._lock:
             with self._thread_lock:
                 log = self._logs[record.job_id]


### PR DESCRIPTION
## Summary
- convert the core contracts from typing.Protocols into abstract base classes with documented semantics for every method
- update the built-in executors, backends, demo executor and logging/event plumbing to inherit from the new contracts and drop `type: ignore` overrides
- refresh the worker and engine tests (plus their helper fakes) to exercise the stricter contracts and deflake the subprocess timeout check

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd9ff30d88325a42828fb1b74bdea)