### PR TITLE
Improve worker shutdown and cancellation handling

### DIFF
--- a/pyjobkit/executors/subprocess.py
+++ b/pyjobkit/executors/subprocess.py
@@ -43,7 +43,12 @@ class SubprocessExecutor(Executor):
                 if stream is None:
                     return
                 while True:
-                    chunk = await stream.readline()
+                    try:
+                        chunk = await asyncio.wait_for(stream.readline(), timeout=1)
+                    except asyncio.TimeoutError:
+                        if proc and proc.returncode is None:
+                            continue
+                        break
                     if not chunk:
                         break
                     await ctx.log(chunk.decode(errors="ignore"), stream=name)


### PR DESCRIPTION
## Summary
- add cooperative cancellation monitoring in the worker and make shutdown drain tasks before force-cancelling
- ensure the CLI requests orderly worker shutdown on interrupts and warnings are emitted when SKIP LOCKED is unavailable
- harden subprocess executor output pumping to avoid hangs when a child process stalls

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e8066bfb08325ac4f23249bf77c7c)