### PR TITLE
Handle cancellation in HTTP executor

### DIFF
--- a/pyjobkit/executors/http.py
+++ b/pyjobkit/executors/http.py
@@ -48,6 +48,9 @@ class HttpExecutor(Executor):
                         "body": body,
                         "duration_ms": duration,
                     }
+                except asyncio.CancelledError:
+                    # Propagate cancellation without retrying so that jobs stop promptly.
+                    raise
                 except Exception as exc:
                     if attempt >= retries:
                         await ctx.log(f"http executor failed: {exc}", stream="stderr")


### PR DESCRIPTION
## Summary
- propagate cancellation exceptions in the HTTP executor without retrying
- adjust the HTTP executor test client helper to surface cancellation
- add a regression test ensuring HTTP cancellation does not trigger retries

## Testing
- pytest tests/test_executors.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e9996eea083258fa2d4a4bb44f9b6)