### PR TITLE
Improve cancellation handling to finalize jobs

### DIFF
--- a/pyjobkit/backends/memory.py
+++ b/pyjobkit/backends/memory.py
@@ -86,6 +86,13 @@ class MemoryBackend(QueueBackend):
             job = self._jobs.get(job_id)
             if job:
                 job.cancel_requested = True
+                if job.status in {"queued", "running"}:
+                    job.status = "cancelled"
+                    job.finished_at = datetime.now(UTC)
+                    job.result = {"error": "cancelled"}
+                    job.lease_until = None
+                    job.leased_by = None
+                    job.version += 1
 
     async def is_cancelled(self, job_id: UUID) -> bool:
         async with self._lock:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -39,6 +39,7 @@ async def _exercise_engine() -> None:
     await engine.cancel(job_id)
     cancelled = await engine.get(job_id)
     assert cancelled["cancel_requested"] is True
+    assert cancelled["status"] == "cancelled"
 
     # Execution context plumbing uses the configured log sink and event bus.
     ctx = engine.make_ctx(job_id)


### PR DESCRIPTION
## Summary
- mark queued or running tasks as cancelled in the backends while recording cancellation metadata
- ensure cancelled tasks are skipped by workers and adjust engine/back-end tests for new semantics

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e9af9f6b48325af4a5b7d4ad3febc)