### PR TITLE
Harden async load test execution

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    integration: integration scenarios that need aligned worker and backend services
+    e2e: end-to-end CLI/API checks
+    load: load and stress tests, executed on demand
+    asyncio: async tests executed with an event loop

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,52 @@
+# Test Suite Overview
+
+This repository uses **pytest** for all automated checks. The suite is split
+into logical layers to mirror the runtime architecture of `pyjobkit`:
+
+- `tests/unit/` – fast and isolated tests for individual components such as
+  executors and the engine facade.
+- `tests/integration/` – multi-component workflows using real backends or
+  worker loops. These are skipped by default because they require external
+  services (PostgreSQL/Redis, Docker daemon, HTTP endpoints).
+- `tests/e2e/` – black-box flows that drive the CLI and API together. These
+  are also skipped unless explicitly enabled via markers.
+- `tests/load/` – stress and soak-style tests that validate throughput,
+  backoff, and lease behaviour under pressure. They are opt-in because they
+  take longer to run.
+
+## Running the suite
+
+```bash
+# Quick feedback (unit only)
+pytest tests/unit
+
+# Full integration and E2E coverage when dependencies are available
+pytest -m "integration or e2e"
+
+# Execute all tests including load/stress (may take several minutes)
+pytest -m "load"
+```
+
+### Markers
+
+The following markers gate slower or environment-dependent checks:
+
+- `integration` – requires external services such as PostgreSQL/Redis and
+  sometimes Docker or HTTP endpoints.
+- `e2e` – runs CLI/API flows end-to-end; expects a running API server and
+  worker processes.
+- `load` – executes high-volume or long-running stress scenarios.
+
+To enable a marker, pass `-m "<marker>"` to `pytest` as shown above. The
+smoke-level unit tests remain fast and environment-independent so they can be
+run in CI by default.
+
+### Current coverage highlights
+
+- Integration scenarios in `tests/integration/test_integration_flow.py` run a
+  worker against `MemoryBackend`, covering the full enqueue → run → success
+  cycle and lease renewal for long-running jobs.
+- The E2E test `tests/e2e/test_e2e_cli_api.py` validates the worker using
+  `HttpExecutor` and reads results/logs through the engine's public API.
+- The load test `tests/load/test_load_stress.py` creates a burst of jobs and
+  ensures the worker remains stable under high parallelism.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    """Allow bare asyncio test functions without external plugins."""
+
+    if asyncio.iscoroutinefunction(pyfuncitem.obj):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(pyfuncitem.obj(**pyfuncitem.funcargs))
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+        return True
+
+    return None

--- a/tests/e2e/test_e2e_cli_api.py
+++ b/tests/e2e/test_e2e_cli_api.py
@@ -1,0 +1,78 @@
+"""End-to-end check: enqueue a job, process it with the worker, and read the result."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Any
+
+import httpx
+import pytest
+
+from pyjobkit.backends.memory import MemoryBackend
+from pyjobkit.engine import Engine
+from pyjobkit.executors.http import HttpExecutor
+from pyjobkit.worker import Worker
+
+
+class _FakeClient:
+    def __init__(self, *_, **__) -> None:
+        self.requests: list[tuple[str, str]] = []
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+    async def request(self, method: str, url: str, **_: Any) -> httpx.Response:
+        self.requests.append((method, url))
+        return httpx.Response(
+            status_code=200,
+            json={"ok": True},
+            headers={"content-type": "application/json"},
+            request=httpx.Request(method, url),
+        )
+
+
+@pytest.mark.e2e
+def test_enqueue_and_fetch_result(monkeypatch) -> None:
+    async def _run() -> None:
+        monkeypatch.setattr("pyjobkit.executors.http.httpx.AsyncClient", _FakeClient)
+
+        backend = MemoryBackend(lease_ttl_s=1)
+        engine = Engine(backend=backend, executors=[HttpExecutor()])
+        worker = Worker(
+            engine,
+            max_concurrency=1,
+            batch=1,
+            poll_interval=0.05,
+            lease_ttl=backend.lease_ttl_s,
+        )
+
+        job_id = await engine.enqueue(kind="http", payload={"url": "https://example"})
+
+        worker_task = asyncio.create_task(worker.run())
+        try:
+            for _ in range(100):
+                row = await engine.get(job_id)
+                if row["status"] == "success":
+                    break
+                await asyncio.sleep(0.05)
+            else:  # pragma: no cover - defensive
+                pytest.fail("job not processed by worker")
+        finally:
+            worker.request_stop()
+            await worker.wait_stopped()
+            worker_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await worker_task
+
+        result = row["result"]
+        assert result["status"] == 200
+        assert result["body"] == {"ok": True}
+
+        logs = await engine.log_sink.get(job_id)
+        assert any("https://example" in entry.message for entry in logs)
+
+    asyncio.run(_run())

--- a/tests/integration/test_integration_flow.py
+++ b/tests/integration/test_integration_flow.py
@@ -1,0 +1,134 @@
+"""Integration scenarios for the worker lifecycle with MemoryBackend."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from uuid import UUID, uuid4
+
+import pytest
+
+from pyjobkit.backends.memory import MemoryBackend
+from pyjobkit.contracts import ExecContext, Executor
+from pyjobkit.engine import Engine
+from pyjobkit.worker import Worker
+
+
+class _EchoExecutor(Executor):
+    kind = "echo"
+
+    def __init__(self) -> None:
+        self.calls: list[UUID] = []
+
+    async def run(self, *, job_id: UUID, payload: dict, ctx: ExecContext) -> dict:
+        await ctx.log(f"echo {payload['value']}")
+        self.calls.append(job_id)
+        await asyncio.sleep(payload.get("sleep", 0))
+        return {"echo": payload["value"]}
+
+
+class _CountingBackend(MemoryBackend):
+    def __init__(self, *, lease_ttl_s: int) -> None:
+        super().__init__(lease_ttl_s=lease_ttl_s)
+        self.extends: list[tuple[UUID, int]] = []
+
+    async def extend_lease(
+        self,
+        job_id: UUID,
+        worker_id: UUID,
+        ttl_s: int,
+        *,
+        expected_version: int | None = None,
+    ) -> None:
+        self.extends.append((job_id, ttl_s))
+        await super().extend_lease(
+            job_id, worker_id, ttl_s, expected_version=expected_version
+        )
+
+
+POLL_INTERVAL = 0.05
+
+
+@pytest.mark.integration
+def test_enqueue_to_success_flow() -> None:
+    async def _run() -> None:
+        backend = MemoryBackend(lease_ttl_s=1)
+        executor = _EchoExecutor()
+        engine = Engine(backend=backend, executors=[executor])
+        worker = Worker(
+            engine,
+            max_concurrency=1,
+            batch=1,
+            poll_interval=POLL_INTERVAL,
+            lease_ttl=backend.lease_ttl_s,
+        )
+
+        job_id = await engine.enqueue(
+            kind=executor.kind, payload={"value": "ok"}, priority=10, timeout_s=5
+        )
+
+        worker_task = asyncio.create_task(worker.run())
+        try:
+            for _ in range(100):
+                row = await engine.get(job_id)
+                if row["status"] == "success":
+                    result = row["result"]
+                    break
+                await asyncio.sleep(POLL_INTERVAL)
+            else:  # pragma: no cover - defensive
+                pytest.fail("job did not finish in time")
+        finally:
+            worker.request_stop()
+            await worker.wait_stopped()
+            worker_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await worker_task
+
+        assert executor.calls == [job_id]
+        assert result == {"echo": "ok"}
+        assert row["attempts"] == 1
+        assert row["lease_until"] is None
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_worker_extends_leases_for_long_jobs() -> None:
+    async def _run() -> None:
+        backend = _CountingBackend(lease_ttl_s=0.2)
+        executor = _EchoExecutor()
+        engine = Engine(backend=backend, executors=[executor])
+        worker = Worker(
+            engine,
+            max_concurrency=1,
+            batch=1,
+            poll_interval=POLL_INTERVAL,
+            lease_ttl=backend.lease_ttl_s,
+        )
+
+        job_id = await engine.enqueue(
+            kind=executor.kind, payload={"value": "slow", "sleep": 0.35}, timeout_s=5
+        )
+
+        worker_task = asyncio.create_task(worker.run())
+        try:
+            for _ in range(120):
+                row = await engine.get(job_id)
+                if row["status"] == "success":
+                    break
+                await asyncio.sleep(POLL_INTERVAL)
+            else:  # pragma: no cover - defensive
+                pytest.fail("job never succeeded")
+        finally:
+            worker.request_stop()
+            await worker.wait_stopped()
+            worker_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await worker_task
+
+        assert row["status"] == "success"
+        assert executor.calls == [job_id]
+        assert len(backend.extends) >= 2
+        assert all(call[0] == job_id for call in backend.extends)
+
+    asyncio.run(_run())

--- a/tests/load/test_load_stress.py
+++ b/tests/load/test_load_stress.py
@@ -1,0 +1,72 @@
+"""Lightweight load scenario to verify worker stability under pressure."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import suppress
+from uuid import UUID
+
+import pytest
+
+from pyjobkit.backends.memory import MemoryBackend
+from pyjobkit.contracts import ExecContext, Executor
+from pyjobkit.engine import Engine
+from pyjobkit.worker import Worker
+
+
+class _FastExecutor(Executor):
+    kind = "fast"
+
+    def __init__(self) -> None:
+        self.completed: list[UUID] = []
+
+    async def run(self, *, job_id: UUID, payload: dict, ctx: ExecContext) -> dict:
+        await asyncio.sleep(0.01)
+        self.completed.append(job_id)
+        return {"ok": True}
+
+
+@pytest.mark.load
+@pytest.mark.asyncio
+async def test_worker_handles_dozen_parallel_jobs() -> None:
+    backend = MemoryBackend(lease_ttl_s=2)
+    executor = _FastExecutor()
+    engine = Engine(backend=backend, executors=[executor])
+    worker = Worker(
+        engine,
+        max_concurrency=10,
+        batch=5,
+        poll_interval=0.01,
+        lease_ttl=backend.lease_ttl_s,
+    )
+
+    job_ids = [
+        await engine.enqueue(kind=executor.kind, payload={"n": i}, priority=50)
+        for i in range(40)
+    ]
+
+    started = time.perf_counter()
+    worker_task = asyncio.create_task(worker.run())
+    try:
+        for _ in range(200):
+            statuses = [await engine.get(job_id) for job_id in job_ids]
+            if all(row["status"] == "success" for row in statuses):
+                break
+            await asyncio.sleep(0.02)
+        else:  # pragma: no cover - defensive
+            pytest.fail(
+                f"Only {len(executor.completed)} of {len(job_ids)} jobs completed"
+            )
+    finally:
+        worker.request_stop()
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(worker.wait_stopped(), timeout=5)
+        worker_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await worker_task
+
+    duration = time.perf_counter() - started
+    print(f"Finished {len(job_ids)} jobs in {duration:.2f}s")
+
+    assert len(executor.completed) == len(job_ids)

--- a/tests/unit/test_executors_additional.py
+++ b/tests/unit/test_executors_additional.py
@@ -1,0 +1,65 @@
+"""Targeted unit tests for executor edge-cases."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from pyjobkit.contracts import ExecContext
+from pyjobkit.executors.subprocess import SubprocessExecutor
+
+
+class _Ctx(ExecContext):
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str]] = []
+
+    async def log(self, message: str, /, *, stream: str = "stdout") -> None:
+        self.records.append((stream, message.strip()))
+
+    async def is_cancelled(self) -> bool:  # pragma: no cover - protocol hook
+        return False
+
+    async def set_progress(self, value: float, /, **meta: Any) -> None:  # pragma: no cover
+        self.records.append(("progress", f"{value}:{meta}"))
+
+
+def test_subprocess_executor_captures_non_zero_exit() -> None:
+    ctx = _Ctx()
+    executor = SubprocessExecutor()
+
+    result = asyncio.run(
+        executor.run(
+            job_id=uuid4(),
+            payload={"cmd": [sys.executable, "-c", "import sys; sys.exit(2)"]},
+            ctx=ctx,
+        )
+    )
+
+    assert result["returncode"] == 2
+    assert any("process exited with code 2" in msg for _, msg in ctx.records)
+
+
+def test_subprocess_executor_terminates_on_cancel() -> None:
+    ctx = _Ctx()
+    executor = SubprocessExecutor()
+
+    async def _run_and_cancel() -> None:
+        task = asyncio.create_task(
+            executor.run(
+                job_id=uuid4(),
+                payload={"cmd": [sys.executable, "-c", "import time; time.sleep(10)"]},
+                ctx=ctx,
+            )
+        )
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_run_and_cancel())
+
+    assert any("terminating process" in msg for _, msg in ctx.records)


### PR DESCRIPTION
## Summary
- convert load stress test to native async with timeout, progress logging, and clearer failures
- add lightweight asyncio runner hook for pytest to execute coroutine tests without external plugins
- register asyncio marker for clarity in pytest configuration

## Testing
- pytest tests/load/test_load_stress.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920980e08808325bef44405f87356fc)